### PR TITLE
Proposal: remove explicit link functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ type Embed struct {
   "name": "Alonzo Church",
   "birthday": {
     "/": {
-      "link": { "/": "bafyreif7dowvi5nuzzijawl22vpqsughufapj455diyflrk7htswzbjid4" }, // DAG-CBOR & SHA2-256
       "data": {
         "day": 14,
         "month": 6
@@ -103,7 +102,6 @@ Explicit encoding and hash algorithm work as normal: the CID MAY be given in adv
   "name": "Alonzo Church",
   "birthday": {
     "/": {
-      "link": null, // Inherits encoding & hash algorithm from container
       "data": {
         "day": 14,
         "month": 6

--- a/README.md
+++ b/README.md
@@ -62,18 +62,7 @@ An inline link MUST be signalled by wrapping in a map with a `"/"` key.
 
 ``` ipldsch
 type EmbedWrapper struct {
-  embed InlineLink (rename "/")
-}
-```
-
-## 2.2 Embedded IPLD Payload
-
-The inlined DAG payload MUST contain the inlined DAG. The CID MAY be present or set to `Null`.
-
-``` ipldsch
-type Embed struct {
-  link nullable &Any
-  data          Any
+  embed Inline (rename ".")
 }
 ```
 
@@ -83,17 +72,15 @@ type Embed struct {
 {
   "name": "Alonzo Church",
   "birthday": {
-    "/": {
-      "data": {
-        "day": 14,
-        "month": 6
-      }
+    ".": {
+      "day": 14,
+      "month": 6
     }
   }
 }
 ```
 
-Explicit encoding and hash algorithm work as normal: the CID MAY be given in advance via the `"link"` field, and MUST validly describe the `"data"` field. 
+Explicit encoding and hash algorithm work as normal: the CID MAY be given in advance via the `"link"` field, and MUST validly describe the `"."` field. 
  
 ### 2.2.2 Inherited
 
@@ -101,11 +88,9 @@ Explicit encoding and hash algorithm work as normal: the CID MAY be given in adv
 {
   "name": "Alonzo Church",
   "birthday": {
-    "/": {
-      "data": {
-        "day": 14,
-        "month": 6
-      }
+    ".": {
+      "day": 14,
+      "month": 6
     }
   }
 }
@@ -146,10 +131,10 @@ flowchart
 
 There are two basic strategies that take advantage of inlining: redundancy and [spanning tree]s. When inlining is not used, the strategy is a form of tabling ([CAR] files and blockstores), and are included here for completeness.
 
-| Representation | Inlining Strategy   | Space | Traversal                      | Typical Implementation      |
-|----------------|---------------------|-------|--------------------------------|-----------------------------|
-| Redundant Tree | Always              | Large | Fast                           | Standard JSON, CBOR, etc    |
-| Spanning Tree  | Once per unique CID | Small | Often slow; depends on content | DAG-JSON, DAG-CBOR, etc     |
+| Representation | Inlining Strategy   | Space  | Traversal                      | Typical Implementation      |
+|----------------|---------------------|--------|--------------------------------|-----------------------------|
+| Redundant Tree | Always              | Large  | Fast                           | Standard JSON, CBOR, etc    |
+| Spanning Tree  | Once per unique CID | Small  | Often slow; depends on content | DAG-JSON, DAG-CBOR, etc     |
 | Table          | Never               | Medium | Medium                         | [CAR] file, blockstore, etc |
 
 These strategies MAY be mixed: there is no way to enforce that they be purely adhered to.
@@ -219,30 +204,12 @@ To calculate the CID of a DAG that contains inline links, first walk the graph a
 ## 4.1 Example
 
 ``` js
-// Implicit inline inside DAG-CBOR with SHA2-256
 {
   "name": "Alonzo Church",
   "birthday": {
-    "/": {
-      "link": null,
-      "data": {
-        "day": 14,
-        "month": 6
-      }
-    }
-  }
-}
-
-// Converted to explicit CID
-{
-  "name": "Alonzo Church",
-  "birthday": {
-    "/": {
-      "link": "bafyreif7dowvi5nuzzijawl22vpqsughufapj455diyflrk7htswzbjid4",
-      "data": {
-        "day": 14,
-        "month": 6
-      }
+    ".": {
+      "day": 14,
+      "month": 6
     }
   }
 }


### PR DESCRIPTION
[📖 Preview](https://github.com/ucan-wg/ipld-inline-links/blob/simplify/README.md)

[A promised](https://github.com/ucan-wg/ipld-inline-links/pull/1#discussion_r1292872326), this a proposed change to #1 that _entirely removes_ the ability to add a CID to an embedded DAG.

_I have only changed the schemata and example, but not the prose or FAQ._ I'll fix those up once I confirm that this is aligned with y'all.

> <img width="799" alt="Screenshot 2023-08-13 at 17 47 54" src="https://github.com/ucan-wg/ipld-inline-links/assets/1052016/7d8f2def-190e-4f56-aa01-aa8e7ee9feab">

This PR doesn't bother with the hash, since we if the condiguration is the same as the currounding context can always calculate it directly from the data, and presumably we want to do that check anyway. If you want to be able to re-encode the outer DAG, then we can't provide a concrete CID anyways.

## Evolvabilty

> we could add later if we find that it's painful without it — much harder to remove it later than add it in later.

The ability to nest arbitrarily configured CIDs isn't in the main use case that I want this for, so please let me know if it's a bigger deal.

I ended up trying a version that's just `"."` as a key. The downside is that this has a might higher chance for a collision with someone else's (userland) schema. A nice thing about `"/"` is that conflicting on `/` is already a case that exists in DAG-JSON. The more fields or nesting that we add, the fewer cases we potentially overlap.

The PR as it stands leaves room for us to add the explicit link back over time without changing the format:

> <img width="754" alt="Screenshot 2023-08-13 at 17 43 37" src="https://github.com/ucan-wg/ipld-inline-links/assets/1052016/1d593fe0-3782-4e5a-b5c4-d0076998c876">

Otherwise, we could keep the nesting to maintain evolvability, which is closer to #1.

```js
// Current PR
{
  "foo": 123,
  "bar": {".": {"some-inner": ["dag", "data"]}}, // Inner DAG
  "baz": "quux"
}

// Back to nesting
{
  "foo": 123,
  "bar": {"/": {".": {"some-inner": ["dag", "data"]}}} // Inner DAG
  "baz": "quux"
}
```

Which both leave open evolving to:

```js
// This PR
{
  "foo": 123,
  "bar": {
    // Flat, with CID
    "/": bafyCid,
    ".": {"some-inner": ["dag", "data"]}
  },
  "baz": "quux"
}

// With nesting & CID
{
  "foo": 123,
  "bar": {
    "/": {
      "&": bafyCid,
      ".": {"some-inner": ["dag", "data"]}
    }
  },
  "baz": "quux"
}
```

These all of course "look" less like other codecs, but they can be easily transformed into DAG-CBOR, etc, which is the point.

I can live with either version, though. Lemme know.